### PR TITLE
Update 8x8 Version to match Winget Version

### DIFF
--- a/Nevergreen/Apps/Get-8x8Work.ps1
+++ b/Nevergreen/Apps/Get-8x8Work.ps1
@@ -1,5 +1,5 @@
 $URL = Get-Link -Uri 'https://support.8x8.com/cloud-phone-service/voice/work-desktop/download-8x8-work-for-desktop' -MatchProperty href -Pattern '\.msi'
 
-$Version = $URL | Get-Version -Pattern '((?:\d+\.)+\d+)'
+$Version = ($URL | Get-Version -Pattern '((?:\d+\.)+\d+-\d+)') -replace "-", "."
 
 New-NevergreenApp -Name '8x8 Work' -Version $Version -Uri $URL -Architecture 'x64' -Type 'msi'

--- a/Nevergreen/Apps/Get-8x8Work.ps1
+++ b/Nevergreen/Apps/Get-8x8Work.ps1
@@ -1,5 +1,5 @@
 $URL = Get-Link -Uri 'https://support.8x8.com/cloud-phone-service/voice/work-desktop/download-8x8-work-for-desktop' -MatchProperty href -Pattern '\.msi'
 
-$Version = ($URL | Get-Version -Pattern '((?:\d+\.)+\d+-\d+)') -replace "-", "."
+$Version = $URL | Get-Version -Pattern '((?:\d+\.)+\d+-\d+)' -ReplaceWithDot
 
 New-NevergreenApp -Name '8x8 Work' -Version $Version -Uri $URL -Architecture 'x64' -Type 'msi'


### PR DESCRIPTION
Wanted to update 8x8 to match the version number that winget provides. 

<img width="643" alt="Screenshot 2023-10-16 at 1 39 35 PM" src="https://github.com/DanGough/Nevergreen/assets/26259981/c1dbd185-e6c0-4da0-91f2-ff56cea7e00e">

Let me know if this makes sense, or if you think there is a better way to do it. 

Thanks!