### PR TITLE
Add Support for Microsoft Visual C++ Redistributables

### DIFF
--- a/Nevergreen/Apps/Get-MicrosoftVisualCPlusPlus.ps1
+++ b/Nevergreen/Apps/Get-MicrosoftVisualCPlusPlus.ps1
@@ -12,7 +12,7 @@ ForEach($Release in $Releases) {
       $Version = Get-Version -Uri 'https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist' -Pattern '<code>((?:\d+\.)+\d+)<\/code>'
       New-NevergreenApp -Name 'Visual C++ 2015-2022 Redistributable' -Version $Version -Uri $URL -Architecture $Release.Architecture -Type $Release.Type
     }
-    ElseIf($Release.VSVersion -eq 'vs2013) {
+    ElseIf($Release.VSVersion -eq 'vs2013') {
       $Version = Get-Version -Uri 'https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist' -Pattern '(12\.(?:\d+\.)+\d+)'
       New-NevergreenApp -Name 'Visual C++ 2013 Redistributable' -Version $Version -Uri $URL -Architecture $Release.Architecture -Type $Release.Type
     }

--- a/Nevergreen/Apps/Get-MicrosoftVisualCPlusPlus.ps1
+++ b/Nevergreen/Apps/Get-MicrosoftVisualCPlusPlus.ps1
@@ -1,0 +1,23 @@
+$Releases = @(
+  @{VSVersion = 'vs2015-2022'; Architecture = 'x64'; Type = 'exe'; Pattern = 'vc_redist\.x64\.exe$'}
+  @{VSVersion = 'vs2015-2022'; Architecture = 'x86'; Type = 'exe'; Pattern = 'vc_redist\.x86\.exe$'}
+  @{VSVersion = 'vs2013'; Architecture = 'x64'; Type = 'exe'; Pattern = 'vcredist_x64\.exe$'}
+  @{VSVersion = 'vs2013'; Architecture = 'x86'; Type = 'exe'; Pattern = 'vcredist_x86\.exe$'}
+)
+
+ForEach($Release in $Releases) {
+  try {
+    $URL = Get-Link -Uri 'https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist' -MatchProperty href -Pattern $Release.Pattern
+    If($Release.VSVersion -eq 'vs2015-2022') {
+      $Version = Get-Version -Uri 'https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist' -Pattern '<code>((?:\d+\.)+\d+)<\/code>'
+      New-NevergreenApp -Name 'Visual C++ 2015-2022 Redistributable' -Version $Version -Uri $URL -Architecture $Release.Architecture -Type $Release.Type
+    }
+    ElseIf($Release.VSVersion -eq 'vs2013) {
+      $Version = Get-Version -Uri 'https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist' -Pattern '(12\.(?:\d+\.)+\d+)'
+      New-NevergreenApp -Name 'Visual C++ 2013 Redistributable' -Version $Version -Uri $URL -Architecture $Release.Architecture -Type $Release.Type
+    }
+  }
+  catch {
+    Write-Error "$($MyInvocation.MyCommand): $($_.Exception.Message)"
+  }
+}


### PR DESCRIPTION
Hello Dan,

This PR adds support for the VC++ 2015-2022 and 2013 redistributable packages. While there is an Evergreen app for VC++, it is a repack and does not come from the source. For me, and for others I know, this introduces some hesitancy to use it. So, I decided to see what we could do with Nevergreen and this is the result.

Microsoft still has downloads for earlier versions of VC++ but they were not added  because they are not supported by Microsoft anymore.

![image](https://github.com/DanGough/Nevergreen/assets/44220748/ed2360a4-06d8-44a5-b3cd-ae52da283ee0)

Test log attached: [Nevergreen.log](https://github.com/DanGough/Nevergreen/files/14407495/Nevergreen.log)
