### PR TITLE
Add Office Deployment Tool

### DIFF
--- a/Nevergreen/Apps/Get-MicrosoftOfficeDeploymentTool.ps1
+++ b/Nevergreen/Apps/Get-MicrosoftOfficeDeploymentTool.ps1
@@ -14,7 +14,7 @@ $Data = Invoke-WebRequest -Uri $DownloadPageUri `
     | ConvertFrom-JSON
 
 New-NeverGreenApp `
-    -Name 'Office Deployment Tool' `
+    -Name 'Microsoft Office Deployment Tool' `
     -Uri $Data.dlcDetailsView.downloadFile.url `
     -Version $Data.dlcDetailsView.downloadFile.Version `
     -Architecture 'Multi' `

--- a/Nevergreen/Apps/Get-OfficeDeploymentTool.ps1
+++ b/Nevergreen/Apps/Get-OfficeDeploymentTool.ps1
@@ -1,7 +1,8 @@
-# get Office Deployment Tool details by using the JSON-Object of the
+# Get Office Deployment Tool details by using the JSON-Object of the
 # Javascript to get the download details.
 $DownloadPageUri = 'https://www.microsoft.com/en-us/download/details.aspx?id=49117'
-# Pattern to get the JSON-Object by matching the script start block + variable declaration to the script end block
+# Pattern to get the JSON-Object by matching the
+# script start block + variable declaration to the script end block.
 $JSONBlobPattern = '(?<scriptStart><script>[\w.]+__DLCDetails__=).*?(?<JSObject-scriptStart></script>)'
 
 $Data = Invoke-WebRequest -Uri $DownloadPageUri `

--- a/Nevergreen/Apps/Get-OfficeDeploymentTool.ps1
+++ b/Nevergreen/Apps/Get-OfficeDeploymentTool.ps1
@@ -1,0 +1,20 @@
+# get Office Deployment Tool details by using the JSON-Object of the
+# Javascript to get the download details.
+$DownloadPageUri = 'https://www.microsoft.com/en-us/download/details.aspx?id=49117'
+# Pattern to get the JSON-Object by matching the script start block + variable declaration to the script end block
+$JSONBlobPattern = '(?<scriptStart><script>[\w.]+__DLCDetails__=).*?(?<JSObject-scriptStart></script>)'
+
+$Data = Invoke-WebRequest -Uri $DownloadPageUri `
+    | Select-Object -Property 'Content' `
+    | Select-String -Pattern $JSONBlobPattern `
+    | Select-Object -ExpandProperty 'Matches' `
+    | ForEach-Object {$_.Groups['JSObject'].Value} `
+    | Select-Object -First 1 `
+    | ConvertFrom-JSON
+
+New-NeverGreenApp `
+    -Name 'Office Deployment Tool' `
+    -Uri $Data.dlcDetailsView.downloadFile.url `
+    -Version $Data.dlcDetailsView.downloadFile.Version `
+    -Architecture 'x64' `
+    -Type 'Exe'

--- a/Nevergreen/Apps/Get-OfficeDeploymentTool.ps1
+++ b/Nevergreen/Apps/Get-OfficeDeploymentTool.ps1
@@ -17,5 +17,5 @@ New-NeverGreenApp `
     -Name 'Office Deployment Tool' `
     -Uri $Data.dlcDetailsView.downloadFile.url `
     -Version $Data.dlcDetailsView.downloadFile.Version `
-    -Architecture 'x64' `
+    -Architecture 'Multi' `
     -Type 'Exe'

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Evergreen relies on API queries to obtain its data, and HTML scraping is not wel
 - Miniconda
 - nmap
 - Npcap
+- Office Deployment Tool
 - Opera
 - OpenVPN Community
 - OpenVPN Connect

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Evergreen relies on API queries to obtain its data, and HTML scraping is not wel
 - LSoft Active Boot Disk
 - Microsoft Azure CLI
 - Microsoft Azure Information Protection UL Client
+- Microsoft Office Deployment Tool
 - Microsoft OpenJDK
 - Microsoft Power BI Desktop
 - Microsoft Power BI Report Builder
@@ -73,7 +74,6 @@ Evergreen relies on API queries to obtain its data, and HTML scraping is not wel
 - Miniconda
 - nmap
 - Npcap
-- Office Deployment Tool
 - Opera
 - OpenVPN Community
 - OpenVPN Connect


### PR DESCRIPTION
Addresses Issue #48

Add the Office Deployment Tool from Microsoft.

This implementation uses the JS-Object ("JSON") from a scriptblock that contains the download informations, converts it to an object and accesses the relevant members.
An alternative would be to scrape the HTML for the same information.

Tested with Powershell 5 (`5.1.19041.4170`) and Powershell 7.4.1.

Example usage and result:

```ps
> Get-NevergreenApp -Name OfficeDeploymentTool

Name         : Office Deployment Tool
Architecture : Multi
Type         : Exe
Version      : 16.0.17328.20162
Uri          : https://download.microsoft.com/download/2/7/A/27AF1BE6-DD20-4CB4-B154-EBAB8A7D4A7E/officedeploymenttool_17328-20162.exe

```
