### PR TITLE
Fix RedstorBackupProStoragePlatformConsole #49

### DIFF
--- a/Nevergreen/Apps/Get-RedstorBackupProStoragePlatformConsole.ps1
+++ b/Nevergreen/Apps/Get-RedstorBackupProStoragePlatformConsole.ps1
@@ -1,15 +1,38 @@
-$GetLinkExtraParams = @{}
-if (-not $IsCoreCLR) {
+$UserAgents = @(
+    $Null,  # No user agent
     # User agent for Edge, taken from the Get-Link example.
-    $GetLinkExtraParams['UserAgent'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246'
-}
-$DownloadPageURL = Get-Link `
-    @GetLinkExtraParams `
-    -Uri 'https://support.redstor.com/hc/en-gb/sections/200458081-Downloads' `
-    -MatchProperty href `
-    -Pattern 'Latest-downloads' `
-    -PrefixDomain
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246',
+    # Chrome 123.0, Windows
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.3',
+    # Edge 123.0, Windows
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36 Edg/123.0.0.',
+    # Opera 108.0, Windows
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 OPR/108.0.0.'
+)
+$DownloadPageURL = $Null
 
+foreach ($UserAgent in $UserAgents) {
+    $GetLinkExtraParams = @{}
+    if ($UserAgent) {
+        $GetLinkExtraParams['UserAgent'] = $UserAgent
+    }
+    try {
+        $DownloadPageURL = Get-Link `
+            @GetLinkExtraParams `
+            -Uri 'https://support.redstor.com/hc/en-gb/sections/200458081-Downloads' `
+            -MatchProperty href `
+            -Pattern 'Latest-downloads' `
+            -PrefixDomain `
+            -ErrorAction Stop
+    } catch {
+        continue
+    }
+    break
+}
+
+if (-not $DownloadPageURL) {
+    Write-Error 'Could not convince the redstor website to skip the challange.'
+}
 
 $URL32 = Get-Link `
     @GetLinkExtraParams `

--- a/Nevergreen/Apps/Get-RedstorBackupProStoragePlatformConsole.ps1
+++ b/Nevergreen/Apps/Get-RedstorBackupProStoragePlatformConsole.ps1
@@ -1,13 +1,7 @@
 $UserAgents = @(
-    $Null,  # No user agent
-    # User agent for Edge, taken from the Get-Link example.
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246',
-    # Chrome 123.0, Windows
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.3',
-    # Edge 123.0, Windows
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36 Edg/123.0.0.',
-    # Opera 108.0, Windows
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 OPR/108.0.0.'
+    $Null
+    # User agent from [Microsoft.PowerShell.Commands.PSUserAgent]::Chrome in PowerShell 7
+    'Mozilla/5.0 (Windows NT 10.0; Microsoft Windows 10.0.22631; en-GB) AppleWebKit/534.6 (KHTML, like Gecko) Chrome/7.0.500.0 Safari/534.6'
 )
 $DownloadPageURL = $Null
 
@@ -31,7 +25,8 @@ foreach ($UserAgent in $UserAgents) {
 }
 
 if (-not $DownloadPageURL) {
-    Write-Error 'Could not convince the redstor website to skip the challange.'
+    Write-Error 'Could not connect to Redstor download page.'
+    return
 }
 
 $URL32 = Get-Link `

--- a/Nevergreen/Apps/Get-RedstorBackupProStoragePlatformConsole.ps1
+++ b/Nevergreen/Apps/Get-RedstorBackupProStoragePlatformConsole.ps1
@@ -1,6 +1,21 @@
-$DownloadPageURL = Get-Link -Uri 'https://support.redstor.com/hc/en-gb/sections/200458081-Downloads' -MatchProperty href -Pattern 'Latest-downloads' -PrefixDomain
+$GetLinkExtraParams = @{}
+if (-not $IsCoreCLR) {
+    # User agent for Edge, taken from the Get-Link example.
+    $GetLinkExtraParams['UserAgent'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246'
+}
+$DownloadPageURL = Get-Link `
+    @GetLinkExtraParams `
+    -Uri 'https://support.redstor.com/hc/en-gb/sections/200458081-Downloads' `
+    -MatchProperty href `
+    -Pattern 'Latest-downloads' `
+    -PrefixDomain
 
-$URL32 = Get-Link -Uri $DownloadPageURL -MatchProperty href -Pattern 'RedstorBackupPro-SP-Console'
+
+$URL32 = Get-Link `
+    @GetLinkExtraParams `
+    -Uri $DownloadPageURL `
+    -MatchProperty href `
+    -Pattern 'RedstorBackupPro-SP-Console'
 
 $Version = $URL32 | Get-Version -Pattern '((?:\d+\.)+\d+)\.exe$'
 


### PR DESCRIPTION
Address Issue #49

Use user agent on PS5 to trick server into serving the website. Do not add user agent on PSCore for the same reason.

Tested on PowerShell 5.1.19041.4170 and PowerShell 7.4.1

```PS
> Get-NevergreenApp RedstorBackupProStoragePlatformConsole


Name         : Redstor Backup Pro Storage Platform Console
Architecture : x86
Type         : Exe
Version      : 24.1.3.12531
Uri          : https://redstorupdates.blob.core.windows.net/redstor/v24.01/Redstor%20Pro/RedstorBackupPro-SP-Console-24.1.3.12531.exe

```

While this works on my machine, I suppose it should be tested on other setups before being accepted.